### PR TITLE
Update leiden.yaml

### DIFF
--- a/workflow/envs/leiden.yaml
+++ b/workflow/envs/leiden.yaml
@@ -11,3 +11,5 @@ dependencies:
   - pandas=1.5.0
   - scipy=1.11.2
   - numpy=1.23.3
+  - dask
+  - pynndescent >=0.5,<0.5.12


### PR DESCRIPTION
NNDescent was throwing errors because of a recent update to pynndescent. This is a temporary fix to limit the version to max 0.5.11 till this bug is fixed.